### PR TITLE
Add pywebpush-based push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Create a **.env** file in the project root:
 SECRET_KEY="replace‑me"
 MAIL_ADDRESS="yourmail@mail.com"
 MAIL_APP_PW="16‑char‑app‑password"
+# VAPID keys for push notifications
+VAPID_PUBLIC_KEY="your-public-key"
+VAPID_PRIVATE_KEY="your-private-key"
 # Optional — defaults to SQLite if unset
 DATABASE_URL="postgresql://user:pass@host:5432/dbname"
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Werkzeug==3.1.1
 WTForms==3.2.1
 gunicorn==23.0.0
 python-dotenv==1.1.0
-psycopg[binary]~=3.1 
+psycopg[binary]~=3.1
+pywebpush==1.14.0
 
 

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  if (!('serviceWorker' in navigator)) return;
+  const reg = await navigator.serviceWorker.register('/static/js/service-worker.js');
+  let sub = await reg.pushManager.getSubscription();
+  if (!sub) {
+    const key = document.querySelector('meta[name="vapid-key"]').content;
+    const converted = urlBase64ToUint8Array(key);
+    sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: converted
+    });
+    await fetch('/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(sub)
+    });
+  }
+});
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - base64String.length % 4) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map(char => char.charCodeAt(0)));
+}

--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -1,0 +1,6 @@
+self.addEventListener('push', function(event) {
+  const data = event.data.json();
+  event.waitUntil(
+    self.registration.showNotification(data.title, { body: data.body })
+  );
+});

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -38,5 +38,6 @@
       <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
       <!-- Core theme JS-->
       <script src="{{ url_for('static', filename='js/scripts.js') }}"></script>
+      <script src="{{ url_for('static', filename='js/push.js') }}"></script>
   </body>
 </html>

--- a/templates/header.html
+++ b/templates/header.html
@@ -8,6 +8,7 @@
     />
     <meta name="description" content="" />
     <meta name="author" content="" />
+    <meta name="vapid-key" content="{{ vapid_public_key }}" />
     <title>Welcome</title>
     {% block styles %}
     <!-- Load Bootstrap-Flask CSS here -->


### PR DESCRIPTION
## Summary
- add `pywebpush` dependency
- store push subscription details in new `PushSubscription` model
- expose `/subscribe` endpoint to save service worker info
- broadcast push messages and emails on new posts and comments
- register service worker and subscription from the UI
- document new `VAPID_*` env vars in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684c952372ec832bb17293e03bb482e0